### PR TITLE
Creates Elasticsearch Image

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+#### What's this PR do?
+
+
+
+#### Where should the reviewer start?
+
+
+
+#### How should this be manually tested?
+
+
+
+#### Any background context you want to provide?
+
+
+
+#### What are the relevant tickets?
+
+
+
+#### Screenshots (if appropriate)
+
+
+
+#### What gif best describes this PR or how it makes you feel?
+
+
+
+#### Definition of Done:
+
+- [ ] Are there breaking changes? Has a representative from each affected team signed-off?

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM elasticsearch:2.4.2
+
+RUN /usr/share/elasticsearch/bin/plugin install analysis-icu

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ https://hub.docker.com/r/doing/elasticsearch/
 
 Builds, testing, and pushing to [Docker Hub](https://hub.docker.com/) are automated via CircleCI. When a tag is created in this repository, CircleCI listens, build a new image and pushes it to Docker Hub using the tag name as the version number. The image can then be referenced elsewhere by `doing/elasticsearch:(version)`.
 
-To be able to do this, CircleCI needs to be able to authenticate with Docker Hub, so the email, username, and password of a Docker Hub user with access to the [Doing Docker Hub organization](https://hub.docker.com/u/doing/dashboard/) shoule be set as environment variables: `DOCKER_EMAIL`, `DOCKER_USER`, and `DOCKER_PASS`.
+To be able to do this, CircleCI needs to be able to authenticate with Docker Hub, so the username, and password of a Docker Hub user with access to the [Doing Docker Hub organization](https://hub.docker.com/u/doing/dashboard/) shoule be set as environment variables: `DOCKER_USER`, and `DOCKER_PASS`.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# doing-docker-elasticsearch
-Our Elasticsearch Docker image
+# Doing Docker Elasticsearch image
+
+Simple Elasticsearch 2.x image with the [ICU Analysis plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/2.4/analysis-icu.html) installed.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # Doing Docker Elasticsearch image
 
-Simple Elasticsearch 2.x image with the [ICU Analysis plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/2.4/analysis-icu.html) installed.
+Simple Elasticsearch 2.x image with the [ICU Analysis plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/2.4/analysis-icu.html) installed:
+
+https://hub.docker.com/r/doing/elasticsearch/
+
+## Installation
+
+### CircleCI
+
+Builds, testing, and pushing to [Docker Hub](https://hub.docker.com/) are automated via CircleCI. When a tag is created in this repository, CircleCI listens, build a new image and pushes it to Docker Hub using the tag name as the version number. The image can then be referenced elsewhere by `doing/elasticsearch:(version)`.
+
+To be able to do this, CircleCI needs to be able to authenticate with Docker Hub, so the email, username, and password of a Docker Hub user with access to the [Doing Docker Hub organization](https://hub.docker.com/u/doing/dashboard/) shoule be set as environment variables: `DOCKER_EMAIL`, `DOCKER_USER`, and `DOCKER_PASS`.

--- a/circle.yml
+++ b/circle.yml
@@ -16,5 +16,5 @@ deployment:
     tag: /v[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?/
     owner: doinginc
     commands:
-      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker login -u $DOCKER_USER -p $DOCKER_PASS
       - docker push doing/elasticsearch:${CIRCLE_TAG}

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,20 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker build --rm=false -t doing/elasticsearch .
+
+test:
+  override:
+    - docker run -d -p 9200:9200 doing/elasticsearch; sleep 10
+    - curl --retry 10 --retry-delay 5 -v http://localhost:9200
+
+deployment:
+  hub:
+    tag: /v[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?/
+    owner: doinginc
+    commands:
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker push doing/elasticsearch:${CIRCLE_TAG}


### PR DESCRIPTION
#### What's this PR do?

Creates a simple Elasticsearch image with the analysis ICU plugin installed so we can reuse it in Docker Compose and maybe eventually even deploy it to a Docker thing to run Elasticsearch on.

Also automates releasing this image via tag creation to be distributed on Docker Hub: https://hub.docker.com/r/doing/elasticsearch/

#### How should this be manually tested?

You can recreate what's in Circle testing:

```bash
docker build --rm=false -t doing/elasticsearch .
docker run -d -p 9200:9200 doing/elasticsearch; sleep 10
curl --retry 10 --retry-delay 5 -v http://localhost:9200
```

#### Any background context you want to provide?

I'm trying to use this for Dockerizing the API  and I'll switch it out for the Docker image being used by the worker too. Basically just creating a centralized place to keep our Elasticsearch image for reuse wherever.

#### What are the relevant tickets?

Refs #209

#### What gif best describes this PR or how it makes you feel?

![Sprinkles](https://media.giphy.com/media/lq6S8PnBMd3Ec/giphy.gif)

#### Definition of Done:

- [ ] Are there breaking changes? Has a representative from each affected team signed-off?
